### PR TITLE
Fix prototype enumeration in case utils

### DIFF
--- a/packages/twenty-server/src/utils/__test__/case-utils.spec.ts
+++ b/packages/twenty-server/src/utils/__test__/case-utils.spec.ts
@@ -1,0 +1,20 @@
+import { camelCaseDeep } from '../camel-case';
+import { snakeCaseDeep } from '../snake-case';
+
+describe('case utils deep functions', () => {
+  class Base { baseProp = 'base'; }
+
+  it('camelCaseDeep should ignore prototype properties', () => {
+    class Foo extends Base { foo_bar = 'baz'; }
+    const obj = new Foo();
+    const result = camelCaseDeep(obj);
+    expect(result).toEqual({ fooBar: 'baz' });
+  });
+
+  it('snakeCaseDeep should ignore prototype properties', () => {
+    class Foo extends Base { fooBar = 'baz'; }
+    const obj = new Foo();
+    const result = snakeCaseDeep(obj);
+    expect(result).toEqual({ foo_bar: 'baz' });
+  });
+});

--- a/packages/twenty-server/src/utils/camel-case.ts
+++ b/packages/twenty-server/src/utils/camel-case.ts
@@ -16,8 +16,8 @@ export const camelCaseDeep = <T>(value: T): CamelCasedPropertiesDeep<T> => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: Record<string, any> = {};
 
-    for (const key in value) {
-      result[camelCase(key)] = camelCaseDeep(value[key]);
+    for (const [key, val] of Object.entries(value)) {
+      result[camelCase(key)] = camelCaseDeep(val as any);
     }
 
     return result as CamelCasedPropertiesDeep<T>;

--- a/packages/twenty-server/src/utils/snake-case.ts
+++ b/packages/twenty-server/src/utils/snake-case.ts
@@ -16,8 +16,8 @@ export const snakeCaseDeep = <T>(value: T): SnakeCasedPropertiesDeep<T> => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: Record<string, any> = {};
 
-    for (const key in value) {
-      result[snakeCase(key)] = snakeCaseDeep(value[key]);
+    for (const [key, val] of Object.entries(value)) {
+      result[snakeCase(key)] = snakeCaseDeep(val as any);
     }
 
     return result as SnakeCasedPropertiesDeep<T>;


### PR DESCRIPTION
## Summary
- avoid iterating over prototype properties in `camelCaseDeep` and `snakeCaseDeep`
- add tests to ensure inherited props are ignored

## Testing
- `npx nx test twenty-server` *(fails: connect EHOSTUNREACH)*